### PR TITLE
Query only OPEN alerts

### DIFF
--- a/vulnerability_alerts.exs
+++ b/vulnerability_alerts.exs
@@ -17,7 +17,6 @@ defmodule VulnerabilityAlerts do
     |> build_query()
     |> request()
     |> handle_response()
-    |> select_actionable_vulnerabilities()
     |> post_to_slack()
   end
 
@@ -28,7 +27,7 @@ defmodule VulnerabilityAlerts do
     {
       repository(owner: "#{owner}", name: "#{name}") {
         nameWithOwner
-        vulnerabilityAlerts(first: 100) {
+        vulnerabilityAlerts(first: 100, states: OPEN) {
           nodes {
             fixedAt
             dismissedAt
@@ -136,13 +135,6 @@ defmodule VulnerabilityAlerts do
       {:ok, dt, _offset} -> dt
       {:error, _} -> datetime_str
     end
-  end
-
-  defp select_actionable_vulnerabilities(vulnerabilities) do
-    vulnerabilities
-    |> Enum.filter(& is_nil(&1.dismissed_at))
-    |> Enum.filter(& is_nil(&1.fixed_at))
-    |> Enum.reject(& &1.state == "FIXED")
   end
 
 end


### PR DESCRIPTION
We started getting false alerts that seemed to include already closed alerts.

This PR should simplify fetching only OPEN alerts.